### PR TITLE
lib: function: staging: boot partition: `c W95 FAT32 (LBA)`

### DIFF
--- a/lib/function/staging
+++ b/lib/function/staging
@@ -7,7 +7,7 @@ parted --script "${IMAGE_FOLDER}${IMAGE_FILE_NAME}" \
 mklabel msdos \
 mkpart primary fat32 ${IMG_OFFSET} 256MiB \
 mkpart primary ext2 256MiB 100%
-parted --script "${IMAGE_FOLDER}${IMAGE_FILE_NAME}" set 1 lba off
+#parted --script "${IMAGE_FOLDER}${IMAGE_FILE_NAME}" set 1 lba off
 parted --script "${IMAGE_FOLDER}${IMAGE_FILE_NAME}" set 1 boot on
 IMAGE_LOOP_DEV="$(losetup --show -P -f ${IMAGE_FOLDER}${IMAGE_FILE_NAME})"
 IMAGE_LOOP_DEV_BOOT="${IMAGE_LOOP_DEV}p1"
@@ -28,7 +28,7 @@ $MOUNT_ROOTFS
 }
 
 filesystem(){
-MAKE_BOOTFS="mkfs.vfat -n BOOT ${IMAGE_LOOP_DEV_BOOT}"
+MAKE_BOOTFS="mkfs -t vfat -n BOOT ${IMAGE_LOOP_DEV_BOOT}"
 BOOT_PATH="/boot/broadcom"
 if [[ "$FSTYPE" == "ext4" ]]; then
 	MAKE_ROOTFS="mkfs.ext4 -L ROOTFS ${IMAGE_LOOP_DEV_ROOTFS}"


### PR DESCRIPTION
This should fix the following issue.
https://github.com/pyavitz/rpi-img-builder/issues/56 https://forums.raspberrypi.com/viewtopic.php?t=278295